### PR TITLE
Registation_allowed is checked to early

### DIFF
--- a/lib/facebook_connect.php
+++ b/lib/facebook_connect.php
@@ -213,14 +213,14 @@ function facebook_connect_create_update_user($fbData) {
 	}
 	// create new user
 	if (!$user) {
-		// check new registration allowed
-		if (!facebook_connect_allow_new_users_with_facebook()) {
-			register_error(elgg_echo('registerdisabled'));
-			forward();
-		}
 		$email= $fbData['user_profile']['email'];
 		$users= get_user_by_email($email);
 		if(!$users) {
+			// check new registration allowed
+		        if (!facebook_connect_allow_new_users_with_facebook()) {
+			       register_error(elgg_echo('registerdisabled'));
+			       forward();
+				}
 			// Elgg-ify facebook credentials
 			if(!empty($fbData['user_profile']['username'])) {
 				$username = $fbData['user_profile']['username'];


### PR DESCRIPTION
The check if registration is allowed must be done after the search of the Elgg user via the facebook email address is failed.
